### PR TITLE
Enable CodeQL security scans

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -4,10 +4,12 @@ description: 'Initialize the project build environment'
 inputs:
   certificate:
     description: 'Code signing key and certificate'
-    required: true
+    required: false
+    default: ''
   password:
     description: 'Password for code signing certificate'
-    required: true
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -21,6 +23,7 @@ runs:
     run: nix profile install $(dirname $(which nix))
 
   - name: Install code signing certificate
+    if: inputs.certificate != ''
     shell: bash
     run: |
       echo ${{ inputs.certificate }} | base64 --decode > codesign.p12
@@ -32,8 +35,14 @@ runs:
       security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ inputs.password }} codesign.keychain
 
   - name: Fixup code signing settings
+    if: inputs.certificate != ''
     shell: bash
     run: sed -i~ '/CODE_SIGN_STYLE/s/Manual/Automatic/;/CODE_SIGN_IDENTITY/{s/Michael Roitzsch/Apple Development/;s/$/\nDEVELOPMENT_TEAM = 599BKLQ4UG;/;}' MovieArchive.xcodeproj/project.pbxproj
+
+  - name: Disable code signing
+    if: inputs.certificate == ''
+    shell: bash
+    run: sed -i~ '/CODE_SIGN_STYLE/s/^/CODE_SIGNING_ALLOWED = NO;/' MovieArchive.xcodeproj/project.pbxproj
 
   - name: Cache dependencies
     id: cache

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -1,0 +1,48 @@
+name: Initialization
+description: 'Initialize the project build environment'
+
+inputs:
+  certificate:
+    description: 'Code signing key and certificate'
+    required: true
+  password:
+    description: 'Password for code signing certificate'
+    required: true
+
+runs:
+  using: 'composite'
+
+  steps:
+  - name: Install Nix
+    uses: cachix/install-nix-action@v18
+
+  - name: Setup Nix profile
+    shell: bash
+    run: nix profile install $(dirname $(which nix))
+
+  - name: Install code signing certificate
+    shell: bash
+    run: |
+      echo ${{ inputs.certificate }} | base64 --decode > codesign.p12
+      security create-keychain -p ${{ inputs.password }} codesign.keychain
+      security set-keychain-settings -lut 21600 codesign.keychain
+      security default-keychain -s codesign.keychain
+      security unlock-keychain -p ${{ inputs.password }} codesign.keychain
+      security import codesign.p12 -t cert -f pkcs12 -P ${{ inputs.password }} -T /usr/bin/codesign -T /usr/bin/productbuild -k codesign.keychain
+      security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ inputs.password }} codesign.keychain
+
+  - name: Fixup code signing settings
+    shell: bash
+    run: sed -i~ '/CODE_SIGN_STYLE/s/Manual/Automatic/;/CODE_SIGN_IDENTITY/{s/Michael Roitzsch/Apple Development/;s/$/\nDEVELOPMENT_TEAM = 599BKLQ4UG;/;}' MovieArchive.xcodeproj/project.pbxproj
+
+  - name: Cache dependencies
+    id: cache
+    uses: actions/cache@v3
+    with:
+      path: Dependencies/Build
+      key: ${{ runner.os }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('.git/modules/Dependencies/HandBrake/HEAD', 'Dependencies/*') }}
+
+  - name: Refresh cached dependencies
+    if: steps.cache.outputs.cache-hit == 'true'
+    shell: bash
+    run: touch Dependencies/Build/*/HandBrake/libhandbrake.a

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -40,9 +40,9 @@ runs:
     uses: actions/cache@v3
     with:
       path: Dependencies/Build
-      key: ${{ runner.os }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('.git/modules/Dependencies/HandBrake/HEAD', 'Dependencies/*') }}
+      key: ${{ runner.os }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('.git/modules/Dependencies/HandBrake/HEAD', 'Dependencies/*') }}-${{ github.workflow }}
+      restore-keys: ${{ runner.os }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('.git/modules/Dependencies/HandBrake/HEAD', 'Dependencies/*') }}
 
   - name: Refresh cached dependencies
-    if: steps.cache.outputs.cache-hit == 'true'
     shell: bash
-    run: touch Dependencies/Build/*/HandBrake/libhandbrake.a
+    run: touch -c Dependencies/Build/*/HandBrake/libhandbrake.a

--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -14,7 +14,7 @@ runs:
 
   steps:
   - name: Install Nix
-    uses: cachix/install-nix-action@v18
+    uses: cachix/install-nix-action@v21
 
   - name: Setup Nix profile
     shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+# static code scan for common security mistakes
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  scan:
+    name: Security scan
+    runs-on: macos-12
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+    permissions:
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Initialize environment
+      uses: ./.github/actions/init
+
+    - name: Initialize CodeQL database
+      uses: github/codeql-action/init@v2
+      with:
+        languages: 'swift'
+
+    - name: Xcode build action
+      run: |
+        xcodebuild build -scheme "Movie Archive" -configuration Debug
+
+    - name: Perform CodeQL analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  check:
-    name: Analyze and test actions
+  tests:
+    name: Analyze and run test
     runs-on: macos-12
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,38 +23,11 @@ jobs:
       with:
         submodules: recursive
 
-    - name: Install Nix
-      uses: cachix/install-nix-action@v18
-
-    - name: Setup Nix profile
-      run: nix profile install $(dirname $(which nix))
-
-    - name: Install code signing certificate
-      env:
-        CODE_SIGN_CERTIFICATE: ${{ secrets.CODE_SIGN_CERTIFICATE }}
-        CODE_SIGN_PASSWORD: ${{ secrets.CODE_SIGN_PASSWORD }}
-      run: |
-        echo $CODE_SIGN_CERTIFICATE | base64 --decode > codesign.p12
-        security create-keychain -p $CODE_SIGN_PASSWORD codesign.keychain
-        security set-keychain-settings -lut 21600 codesign.keychain
-        security default-keychain -s codesign.keychain
-        security unlock-keychain -p $CODE_SIGN_PASSWORD codesign.keychain
-        security import codesign.p12 -t cert -f pkcs12 -P $CODE_SIGN_PASSWORD -T /usr/bin/codesign -T /usr/bin/productbuild -k codesign.keychain
-        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $CODE_SIGN_PASSWORD codesign.keychain
-
-    - name: Fixup code signing settings
-      run: sed -i~ '/CODE_SIGN_STYLE/s/Manual/Automatic/;/CODE_SIGN_IDENTITY/{s/Michael Roitzsch/Apple Development/;s/$/\nDEVELOPMENT_TEAM = 599BKLQ4UG;/;}' MovieArchive.xcodeproj/project.pbxproj
-
-    - name: Cache dependencies
-      id: cache
-      uses: actions/cache@v3
+    - name: Initialize environment
+      uses: ./.github/actions/init
       with:
-        path: Dependencies/Build
-        key: ${{ runner.os }}-${{ runner.arch }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('.git/modules/Dependencies/HandBrake/HEAD', 'Dependencies/*') }}
-
-    - name: Refresh cached dependencies
-      if: steps.cache.outputs.cache-hit == 'true'
-      run: touch Dependencies/Build/*/HandBrake/libhandbrake.a
+        certificate: ${{ secrets.CODE_SIGN_CERTIFICATE }}
+        password: ${{ secrets.CODE_SIGN_PASSWORD }}
 
     - name: Xcode build action
       run: |
@@ -69,6 +42,3 @@ jobs:
 
     - name: Xcode docbuild action
       run: xcodebuild docbuild -scheme "Movie Archive"
-
-    - name: Remove codesigning certificate
-      run: security delete-keychain codesign.keychain


### PR DESCRIPTION
GitHub’s CodeQL tool to scan code for security problems now supports the Swift programming language. Enable CodeQL scanning using a GitHub actions workflow.